### PR TITLE
fix sqlite-vss loadable path resolution

### DIFF
--- a/extensions/sqlite-vss/src/SQLiteVectorIndex.ts
+++ b/extensions/sqlite-vss/src/SQLiteVectorIndex.ts
@@ -35,10 +35,9 @@ function loadablePathResolver(name: string) {
   }
   const packageName = platformPackageName(platform, arch);
   const loadablePath = join(
-    __filename,
+    __dirname,
     "..",
     "..",
-    "node_modules",
     packageName,
     "lib",
     `${name}.${extensionSuffix(platform)}`


### PR DESCRIPTION
I messed up the path resolution for the sqlite vss dlls. I think it's because the way I linked the package during development was by doing `npm install ../../extensions/sqlite-vss/dist`. So the resolution path is different when installed normally through npm. I tested this in a project and I'm fairly sure it's correct now.

__dirname will be .../node_modules/@modelfusion/sqlite-vss
navigate up two directories to get to .../node_modules
then packageName/lib/${name}.${extensionSuffix(platform)} to find the correct library