### PR TITLE
Prompt format improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,11 +479,22 @@ const retrievedTexts = await retrieve(
 
 Available Vector Stores: [Memory](https://modelfusion.dev/integration/vector-index/memory), [SQLite VSS](https://modelfusion.dev/integration/vector-index/sqlite-vss), [Pinecone](https://modelfusion.dev/integration/vector-index/pinecone)
 
-### Prompt Formats
+### [Text Generation Prompt Formats](https://modelfusion.dev/guide/function/generate-text#prompt-format)
 
-Prompt formats let you use higher level prompt structures (such as instruction or chat prompts) for different models.
+Prompt formats let you use higher level prompt structures (such as text, instruction or chat prompts) for different models.
 
-#### [Text Generation Prompt Formats](https://modelfusion.dev/guide/function/generate-text#prompt-format)
+#### Text Prompt Example
+
+```ts
+const text = await generateText(
+  new AnthropicTextGenerationModel({
+    model: "claude-instant-1",
+  }).withTextPrompt(),
+  "Write a short story about a robot learning to love"
+);
+```
+
+#### Instruction Prompt Example
 
 ```ts
 // example assumes you are running https://huggingface.co/TheBloke/Llama-2-7B-GGUF with llama.cpp
@@ -491,9 +502,7 @@ const text = await generateText(
   new LlamaCppTextGenerationModel({
     contextWindowSize: 4096, // Llama 2 context window size
     maxCompletionTokens: 1000,
-  })
-    .withTextPrompt() // pure text prompt (no images)
-    .withPromptFormat(Llama2PromptFormat.instruction()),
+  }).withTextPromptFormat(Llama2PromptFormat.instruction()),
   {
     system: "You are a story writer.",
     instruction: "Write a short story about a robot learning to love.",
@@ -501,7 +510,9 @@ const text = await generateText(
 );
 ```
 
-They can also be accessed through the shorthand methods `.withChatPrompt()` and `.withInstructionPrompt()` for many models:
+They can also be accessed through the shorthand methods `.withTextPrompt()`, `.withChatPrompt()` and `.withInstructionPrompt()` for many models:
+
+#### Chat Prompt Example
 
 ```ts
 const textStream = await streamText(
@@ -528,19 +539,17 @@ const textStream = await streamText(
 );
 ```
 
-| Prompt Format | Instruction Prompt | Chat Prompt |
-| ------------- | ------------------ | ----------- |
-| OpenAI Chat   | ✅                 | ✅          |
-| Anthropic     | ✅                 | ✅          |
-| Llama 2       | ✅                 | ✅          |
-| ChatML        | ✅                 | ✅          |
-| Alpaca        | ✅                 | ❌          |
-| Vicuna        | ❌                 | ✅          |
-| Generic Text  | ✅                 | ✅          |
+| Prompt Format | Text Prompt | Instruction Prompt | Chat Prompt |
+| ------------- | ----------- | ------------------ | ----------- |
+| OpenAI Chat   | ✅          | ✅                 | ✅          |
+| Anthropic     | ✅          | ✅                 | ✅          |
+| Llama 2       | ✅          | ✅                 | ✅          |
+| ChatML        | ✅          | ✅                 | ✅          |
+| Alpaca        | ✅          | ✅                 | ❌          |
+| Vicuna        | ❌          | ❌                 | ✅          |
+| Generic Text  | ✅          | ✅                 | ✅          |
 
-#### [Vision Prompts]
-
-#### [Image Generation Prompt Formats](https://modelfusion.dev/guide/function/generate-image/prompt-format)
+### [Image Generation Prompt Formats](https://modelfusion.dev/guide/function/generate-image/prompt-format)
 
 You an use prompt formats with image models as well, e.g. to use a basic text prompt. It is available as a shorthand method:
 

--- a/docs/guide/function/generate-text.md
+++ b/docs/guide/function/generate-text.md
@@ -104,7 +104,55 @@ This enables the use of abstracted prompts such as [instruction](/api/modules#in
 
 You can map the prompt of a [TextGenerationModel](/api/interfaces/TextGenerationModel) using the `withPromptFormat()` method.
 
-For convenience, models with clear prompt formats have a `withChatPrompt()` or `withInstructionPrompt()` method that automatically applies the correct prompt format.
+For convenience, models with clear prompt formats have a `withTextPrompt()`, `withChatPrompt()`, or `withInstructionPrompt()` method that automatically applies the correct prompt format.
+
+### Text Prompts
+
+Text prompts are a simple string prompts. They are useful for mapping a simple prompt into the specific prompt format that a model expects.
+
+#### Example: OpenAIChatPromptFormat
+
+```ts
+const model = new OpenAIChatModel({
+  // ...
+}).withPromptFormat(OpenAIChatPromptFormat.text());
+```
+
+[OpenAIChatPromptFormat.text()](/api/namespaces/OpenAIChatPromptFormat#text) formats the instruction as an OpenAI message prompt, which is expected by the [OpenAIChatModel](/api/classes/OpenAIChatModel).
+
+Alternatively you can use the shorthand method:
+
+```ts
+const model = new OpenAIChatModel({
+  // ...
+}).withTextPrompt();
+```
+
+You can now generate text using a basic text prompt:
+
+```ts
+const text = await generateText(
+  model,
+  "Write a story about a robot learning to love"
+);
+```
+
+#### Prompt Formats
+
+The following prompt formats are available for text prompts:
+
+- **OpenAI chat**: [OpenAIChatPromptFormat.text()](/api/namespaces/OpenAIChatPromptFormat#text)
+  for [OpenAI chat models](/api/classes/OpenAIChatModel).
+- **Anthropic**: [AnthropicPromptFormat.text()](/api/namespaces/AnthropicPromptFormat#text)
+  for [Anthropic models](/api/classes/AnthropicTextGenerationModel).
+- **Llama 2**: [Llama2PromptFormat.text()](/api/namespaces/Llama2PromptFormat#text)
+  for models that use the [Llama 2 prompt format](https://www.philschmid.de/llama-2#how-to-prompt-llama-2-chat).
+- **Alpaca**: [AlpacaPromptFormat.text()](/api/namespaces/AlpacaPromptFormat#text)
+  for models that use the [Alpaca prompt format](https://github.com/tatsu-lab/stanford_alpaca#data-release).
+- **ChatML**: [ChatMLPromptFormat.text()](/api/namespaces/ChatMLPromptFormat#text)
+  for models that use the ChatML prompt format.
+- **Basic text**: [TextPromptFormat.text()](/api/namespaces/TextPromptFormat#text)
+  for other models that expect a generic text prompt.
 
 ### Instruction Prompts
 

--- a/docs/guide/function/generate-text.md
+++ b/docs/guide/function/generate-text.md
@@ -135,8 +135,7 @@ You can now generate text using an instruction prompt:
 ```ts
 const text = await generateText(model, {
   system: "You are a celebrated poet.", // optional
-  instruction: "Write a short story about:",
-  input: "a robot learning to love", // optional
+  instruction: "Write a story about a robot learning to love",
 });
 ```
 

--- a/docs/guide/guard.md
+++ b/docs/guide/guard.md
@@ -70,9 +70,7 @@ const result = await guard(
     generateText(
       new LlamaCppTextGenerationModel({
         // ...
-      })
-        .withTextPrompt() // pure text prompt (no images)
-        .withPromptFormat(Llama2PromptFormat.instruction()),
+      }).withTextPromptFormat(Llama2PromptFormat.instruction()),
       input,
       options // pass through options (for tracing)
     ),

--- a/docs/integration/model-provider/anthropic.md
+++ b/docs/integration/model-provider/anthropic.md
@@ -75,6 +75,19 @@ for await (const textPart of textStream) {
 Anthropic requires a very specific prompt format with "Human: " and "Assistant: " sections.
 Using a prompt mapping can make the interaction with Anthropic models easier.
 
+### Text prompt
+
+[AnthropicPromptFormat.text()](/api/namespaces/AnthropicPromptFormat) lets you use basic text prompts with Anthropic models. It is available as a shorthand method:
+
+```ts
+const textStream = await streamText(
+  new AnthropicTextGenerationModel({
+    // ...
+  }).withTextPrompt(),
+  "Write a short story about a robot learning to love"
+);
+```
+
 ### Instruction prompt
 
 [AnthropicPromptFormat.instruction()](/api/namespaces/AnthropicPromptFormat) lets you use [instruction prompts](/api/modules#instructionprompt) with Anthropic models. It is available as a shorthand method:

--- a/docs/integration/model-provider/llamacpp.md
+++ b/docs/integration/model-provider/llamacpp.md
@@ -67,7 +67,6 @@ const model = new LlamaCppTextGenerationModel({
 [LlamaCppTextGenerationModel API](/api/classes/LlamaCppTextGenerationModel)
 
 Consider [mapping the prompt to the prompt format](#prompt-formats) that your model was trained on.
-For models that take text input, you can first map the prompt to a simpler format using `.withTextPrompt()`.
 
 ```ts
 import { LlamaCppTextGenerationModel, generateText } from "modelfusion";

--- a/docs/integration/model-provider/llamacpp.md
+++ b/docs/integration/model-provider/llamacpp.md
@@ -282,7 +282,7 @@ const textStream = await streamText(
     .withPromptFormat(AlpacaPromptFormat.instruction()),
   {
     instruction: "You are a celebrated poet. Write a short story about:",
-    input: "a robot learning to love.",
+    input: "a robot learning to love.", // Alpaca supports optional input field
   }
 );
 ```

--- a/docs/integration/model-provider/llamacpp.md
+++ b/docs/integration/model-provider/llamacpp.md
@@ -161,6 +161,19 @@ The prompt format that the model expected is usually described on the model card
 
 Llama 2 uses a special prompt format (see "[How to prompt Llama 2 chat](https://www.philschmid.de/llama-2#how-to-prompt-llama-2-chat)"):
 
+#### Text prompt format
+
+You can use [Llama2PromptFormat.text()](/api/namespaces/Llama2PromptFormat#text) to create basic text prompts.
+
+```ts
+const textStream = await streamText(
+  new LlamaCppTextGenerationModel({
+    // ...
+  }).withTextPromptFormat(Llama2PromptFormat.text()),
+  "Write a short story about a robot learning to love."
+);
+```
+
 #### Instruction prompt format
 
 You can use [Llama2PromptFormat.instruction()](/api/namespaces/Llama2PromptFormat#instruction) to create instruction prompts.
@@ -169,9 +182,7 @@ You can use [Llama2PromptFormat.instruction()](/api/namespaces/Llama2PromptForma
 const textStream = await streamText(
   new LlamaCppTextGenerationModel({
     // ...
-  })
-    .withTextPrompt() // pure text prompt (no images)
-    .withPromptFormat(Llama2PromptFormat.instruction()),
+  }).withTextPromptFormat(Llama2PromptFormat.instruction()),
   {
     system: "You are a celebrated poet.",
     instruction: "Write a short story about a robot learning to love.",
@@ -187,9 +198,7 @@ You can use [Llama2PromptFormat.chat()](/api/namespaces/Llama2PromptFormat#chat)
 const textStream = await streamText(
   new LlamaCppTextGenerationModel({
     // ...
-  })
-    .withTextPrompt() // pure text prompt (no images)
-    .withPromptFormat(Llama2PromptFormat.chat()),
+  }).withTextPromptFormat(Llama2PromptFormat.chat()),
   {
     system: "You are a celebrated poet.",
     messages: [
@@ -214,6 +223,19 @@ const textStream = await streamText(
 
 ChatML is a prompt format that is used by several models, e.g. [OpenHermes-2.5-Mistral](https://huggingface.co/TheBloke/OpenHermes-2.5-Mistral-7B-GGUF).
 
+#### Text prompt format
+
+You can use [ChatMLPromptFormat.text()](/api/namespaces/ChatMLPromptFormat#text) to create basic text prompts.
+
+```ts
+const textStream = await streamText(
+  new LlamaCppTextGenerationModel({
+    // ...
+  }).withTextPromptFormat(ChatMLPromptFormat.text()),
+  "Write a short story about a robot learning to love."
+);
+```
+
 #### Instruction prompt format
 
 You can use [ChatMLPromptFormat.instruction()](/api/namespaces/ChatMLPromptFormat#instruction) to create instruction prompts.
@@ -222,9 +244,7 @@ You can use [ChatMLPromptFormat.instruction()](/api/namespaces/ChatMLPromptForma
 const textStream = await streamText(
   new LlamaCppTextGenerationModel({
     // ...
-  })
-    .withTextPrompt() // pure text prompt (no images)
-    .withPromptFormat(ChatMLPromptFormat.instruction()),
+  }).withTextPromptFormat(ChatMLPromptFormat.instruction()),
   {
     instruction: "Write a short story about a robot learning to love.",
   }
@@ -239,9 +259,7 @@ You can use [ChatMLPromptFormat.chat()](/api/namespaces/ChatMLPromptFormat#chat)
 const textStream = await streamText(
   new LlamaCppTextGenerationModel({
     // ...
-  })
-    .withTextPrompt() // pure text prompt (no images)
-    .withPromptFormat(ChatMLPromptFormat.chat()),
+  }).withTextPromptFormat(ChatMLPromptFormat.chat()),
   {
     messages: [
       {
@@ -265,6 +283,19 @@ const textStream = await streamText(
 
 Alpaca and several other models use the [Alpaca prompt format](https://github.com/tatsu-lab/stanford_alpaca#data-release):
 
+#### text prompt format
+
+You can use [AlpacaPromptFormat.text()](/api/namespaces/AlpacaPromptFormat#text) to create basic text prompts.
+
+```ts
+const textStream = await streamText(
+  new LlamaCppTextGenerationModel({
+    // ...
+  }).withTextPromptFormat(AlpacaPromptFormat.text()),
+  "Write a short story about a robot learning to love."
+);
+```
+
 #### instruction prompt format
 
 You can use [AlpacaPromptFormat.instruction()](/api/namespaces/AlpacaPromptFormat#instruction) to create instruction prompts.
@@ -277,9 +308,7 @@ Setting the system property overrides the Alpaca system prompt and can impact th
 const textStream = await streamText(
   new LlamaCppTextGenerationModel({
     // ...
-  })
-    .withTextPrompt() // pure text prompt (no images)
-    .withPromptFormat(AlpacaPromptFormat.instruction()),
+  }).withTextPromptFormat(AlpacaPromptFormat.instruction()),
   {
     instruction: "You are a celebrated poet. Write a short story about:",
     input: "a robot learning to love.", // Alpaca supports optional input field
@@ -303,9 +332,7 @@ Setting the system property overrides the Vicuna system prompt and can impact th
 const textStream = await streamText(
   new LlamaCppTextGenerationModel({
     // ...
-  })
-    .withTextPrompt() // pure text prompt (no images)
-    .withPromptFormat(VicunaPromptFormat.chat()),
+  }).withTextPromptFormat(VicunaPromptFormat.chat()),
   {
     system: "You are a celebrated poet.",
     messages: [

--- a/docs/integration/model-provider/openai.md
+++ b/docs/integration/model-provider/openai.md
@@ -298,6 +298,19 @@ fs.writeFileSync(path, speech);
 
 ### OpenAI Chat Format
 
+#### Text prompt
+
+[OpenAIChatPromptFormat.text()](/api/namespaces/OpenAIChatPromptFormat) lets you use basic text prompts with OpenAI chat models. It is available as a shorthand method:
+
+```ts
+const textStream = await streamText(
+  new OpenAIChatModel({
+    // ...
+  }).withTextPrompt(),
+  "Write a short story about a robot learning to love."
+);
+```
+
 #### Instruction prompt
 
 [OpenAIChatPromptFormat.instruction()](/api/namespaces/OpenAIChatPromptFormat) lets you use [instruction prompts](/api/modules#instructionprompt) with OpenAI chat models. It is available as a shorthand method:

--- a/examples/basic/src/guard/guard-redact-sensitive-information.ts
+++ b/examples/basic/src/guard/guard-redact-sensitive-information.ts
@@ -21,9 +21,7 @@ async function main() {
         new LlamaCppTextGenerationModel({
           temperature: 0.7,
           maxCompletionTokens: 500,
-        })
-          .withTextPrompt() // pure text prompt (no images)
-          .withPromptFormat(Llama2PromptFormat.instruction()),
+        }).withTextPromptFormat(Llama2PromptFormat.instruction()),
         input,
         options
       ),

--- a/examples/basic/src/model-function/stream-text-full-response-and-observer-example.ts
+++ b/examples/basic/src/model-function/stream-text-full-response-and-observer-example.ts
@@ -21,10 +21,7 @@ async function main() {
       model: "gpt-3.5-turbo-instruct",
       maxCompletionTokens: 500,
     }).withInstructionPrompt(),
-    {
-      instruction: "You are a story writer. Write a story about:",
-      input: "A robot learning to love",
-    },
+    { instruction: "Write a story about a robot learning to love" },
     {
       functionId: "generate-story",
       returnType: "full",

--- a/examples/basic/src/model-function/stream-text-instruction-prompt-example.ts
+++ b/examples/basic/src/model-function/stream-text-instruction-prompt-example.ts
@@ -1,0 +1,23 @@
+import dotenv from "dotenv";
+import { OpenAIChatModel, streamText } from "modelfusion";
+
+dotenv.config();
+
+async function main() {
+  const textStream = await streamText(
+    new OpenAIChatModel({
+      model: "gpt-3.5-turbo",
+      temperature: 0.7,
+      maxCompletionTokens: 500,
+    }).withInstructionPrompt(),
+    {
+      instruction: "Write a short story about a robot learning to love.",
+    }
+  );
+
+  for await (const textPart of textStream) {
+    process.stdout.write(textPart);
+  }
+}
+
+main().catch(console.error);

--- a/examples/basic/src/model-function/stream-text-text-prompt-example.ts
+++ b/examples/basic/src/model-function/stream-text-text-prompt-example.ts
@@ -1,0 +1,21 @@
+import dotenv from "dotenv";
+import { OpenAIChatModel, streamText } from "modelfusion";
+
+dotenv.config();
+
+async function main() {
+  const textStream = await streamText(
+    new OpenAIChatModel({
+      model: "gpt-3.5-turbo",
+      temperature: 0.7,
+      maxCompletionTokens: 500,
+    }).withTextPrompt(),
+    "Write a short story about a robot learning to love."
+  );
+
+  for await (const textPart of textStream) {
+    process.stdout.write(textPart);
+  }
+}
+
+main().catch(console.error);

--- a/examples/basic/src/model-provider/anthropic/anthropic-stream-text-chat-prompt-example.ts
+++ b/examples/basic/src/model-provider/anthropic/anthropic-stream-text-chat-prompt-example.ts
@@ -1,10 +1,10 @@
 import dotenv from "dotenv";
-import { AnthropicTextGenerationModel, generateText } from "modelfusion";
+import { AnthropicTextGenerationModel, streamText } from "modelfusion";
 
 dotenv.config();
 
 async function main() {
-  const text = await generateText(
+  const textStream = await streamText(
     new AnthropicTextGenerationModel({
       model: "claude-instant-1",
       temperature: 0.7,
@@ -29,7 +29,9 @@ async function main() {
     }
   );
 
-  console.log(text);
+  for await (const textPart of textStream) {
+    process.stdout.write(textPart);
+  }
 }
 
 main().catch(console.error);

--- a/examples/basic/src/model-provider/anthropic/anthropic-stream-text-text-prompt-example.ts
+++ b/examples/basic/src/model-provider/anthropic/anthropic-stream-text-text-prompt-example.ts
@@ -1,0 +1,21 @@
+import dotenv from "dotenv";
+import { AnthropicTextGenerationModel, streamText } from "modelfusion";
+
+dotenv.config();
+
+async function main() {
+  const textStream = await streamText(
+    new AnthropicTextGenerationModel({
+      model: "claude-instant-1",
+      temperature: 0.7,
+      maxCompletionTokens: 500,
+    }).withTextPrompt(),
+    "Write a short story about a robot learning to love"
+  );
+
+  for await (const textPart of textStream) {
+    process.stdout.write(textPart);
+  }
+}
+
+main().catch(console.error);

--- a/examples/basic/src/model-provider/cohere/cohere-generate-text-instruction-prompt-example.ts
+++ b/examples/basic/src/model-provider/cohere/cohere-generate-text-instruction-prompt-example.ts
@@ -11,8 +11,7 @@ async function main() {
     }).withInstructionPrompt(),
     {
       system: "You are a celebrated poet.",
-      instruction: "Write a short story about:",
-      input: "a robot learning to love",
+      instruction: "Write a story about a robot learning to love",
     }
   );
 

--- a/examples/basic/src/model-provider/llamacpp/llamacpp-stream-text-with-alpaca-instruction-prompt-example.ts
+++ b/examples/basic/src/model-provider/llamacpp/llamacpp-stream-text-with-alpaca-instruction-prompt-example.ts
@@ -15,7 +15,7 @@ async function main() {
       .withPromptFormat(AlpacaPromptFormat.instruction()),
     {
       instruction: "You are a celebrated poet. Write a short story about:",
-      input: "a robot learning to love.",
+      input: "a robot learning to love.", // Alpaca format supports optional input
     }
   );
 

--- a/examples/basic/src/model-provider/llamacpp/llamacpp-stream-text-with-alpaca-instruction-prompt-example.ts
+++ b/examples/basic/src/model-provider/llamacpp/llamacpp-stream-text-with-alpaca-instruction-prompt-example.ts
@@ -10,9 +10,7 @@ async function main() {
     new LlamaCppTextGenerationModel({
       contextWindowSize: 2048, // context window size of Chronos-13B-v2
       maxCompletionTokens: 1024,
-    })
-      .withTextPrompt() // pure text prompt (no images)
-      .withPromptFormat(AlpacaPromptFormat.instruction()),
+    }).withTextPromptFormat(AlpacaPromptFormat.instruction()),
     {
       instruction: "You are a celebrated poet. Write a short story about:",
       input: "a robot learning to love.", // Alpaca format supports optional input

--- a/examples/basic/src/model-provider/llamacpp/llamacpp-stream-text-with-chatml-chat-prompt-example.ts
+++ b/examples/basic/src/model-provider/llamacpp/llamacpp-stream-text-with-chatml-chat-prompt-example.ts
@@ -13,9 +13,7 @@ async function main() {
     new LlamaCppTextGenerationModel({
       contextWindowSize: 4096,
       maxCompletionTokens: 512,
-    })
-      .withTextPrompt()
-      .withPromptFormat(ChatMLPromptFormat.chat()),
+    }).withTextPromptFormat(ChatMLPromptFormat.chat()),
     {
       system: "You are a celebrated poet.",
       messages: [

--- a/examples/basic/src/model-provider/llamacpp/llamacpp-stream-text-with-llama2-chat-prompt-example.ts
+++ b/examples/basic/src/model-provider/llamacpp/llamacpp-stream-text-with-llama2-chat-prompt-example.ts
@@ -13,9 +13,7 @@ async function main() {
     new LlamaCppTextGenerationModel({
       contextWindowSize: 4096, // Llama 2 context window size
       maxCompletionTokens: 512,
-    })
-      .withTextPrompt() // pure text prompt (no images)
-      .withPromptFormat(Llama2PromptFormat.chat()),
+    }).withTextPromptFormat(Llama2PromptFormat.chat()),
     {
       system: "You are a celebrated poet.",
       messages: [

--- a/examples/basic/src/model-provider/llamacpp/llamacpp-stream-text-with-llama2-text-prompt-example.ts
+++ b/examples/basic/src/model-provider/llamacpp/llamacpp-stream-text-with-llama2-text-prompt-example.ts
@@ -10,11 +10,8 @@ async function main() {
     new LlamaCppTextGenerationModel({
       contextWindowSize: 4096, // Llama 2 context window size
       maxCompletionTokens: 512,
-    }).withTextPromptFormat(Llama2PromptFormat.instruction()),
-    {
-      system: "You are a celebrated poet.",
-      instruction: "Write a short story about a robot learning to love.",
-    }
+    }).withTextPromptFormat(Llama2PromptFormat.text()),
+    "Write a short story about a robot learning to love."
   );
 
   for await (const textPart of textStream) {

--- a/examples/basic/src/model-provider/llamacpp/llamacpp-stream-text-with-vicuna-chat-prompt-example.ts
+++ b/examples/basic/src/model-provider/llamacpp/llamacpp-stream-text-with-vicuna-chat-prompt-example.ts
@@ -13,9 +13,7 @@ async function main() {
     new LlamaCppTextGenerationModel({
       contextWindowSize: 2048, // Vicuna v1.5 context window size
       maxCompletionTokens: 512,
-    })
-      .withTextPrompt() // pure text prompt (no images)
-      .withPromptFormat(VicunaPromptFormat.chat()),
+    }).withTextPromptFormat(VicunaPromptFormat.chat()),
     {
       system: "You are a celebrated poet.",
       messages: [

--- a/examples/basic/src/model-provider/ollama/ollama-use-tool-mistral-example.ts
+++ b/examples/basic/src/model-provider/ollama/ollama-use-tool-mistral-example.ts
@@ -2,65 +2,12 @@ import dotenv from "dotenv";
 import {
   OllamaTextGenerationModel,
   TextGenerationToolCallModel,
-  ToolCallTextPromptFormat,
-  ToolDefinition,
-  ZodSchema,
-  parseJSON,
+  FunctionListToolCallPromptFormat,
   useTool,
 } from "modelfusion";
-import { nanoid } from "nanoid";
-import { z } from "zod";
 import { calculator } from "../../tool/calculator-tool";
 
 dotenv.config();
-
-// schema for prompt
-const functionSchema = new ZodSchema(
-  z.object({
-    function: z.string(),
-    params: z.any(),
-  })
-);
-
-class CalculatorFunctionPromptFormat
-  implements ToolCallTextPromptFormat<string>
-{
-  createPrompt(
-    instruction: string,
-    tool: ToolDefinition<string, unknown>
-  ): string {
-    // map parameters JSON schema
-    const properties: Record<string, { type: string; description: string }> = (
-      tool.parameters.getJsonSchema() as any
-    ).properties; // unsafe, assuming 1 level deep
-    return [
-      `As an AI assistant, please select the most suitable function and parameters ` +
-        `from the list of available functions below, based on the user's input. ` +
-        `Provide your response in JSON format.`,
-      ``,
-      `Available functions:`,
-      `${tool.name}:`,
-      `  description: ${tool.description ?? ""}`,
-      `  params:`,
-      // Note: Does support nested schemas yet
-      ...Object.entries(properties).map(
-        ([name, { type, description }]) =>
-          `    ${name}: (${type}) ${description}`
-      ),
-      ``,
-      `Input: ${instruction}`,
-      ``,
-    ].join("\n");
-  }
-
-  extractToolCall(response: string) {
-    const json = parseJSON({ text: response, schema: functionSchema });
-    return {
-      id: nanoid(),
-      args: json.params,
-    };
-  }
-}
 
 async function main() {
   const { tool, args, toolCall, result } = await useTool(
@@ -70,7 +17,7 @@ async function main() {
         format: "json",
         temperature: 0,
       }),
-      format: new CalculatorFunctionPromptFormat(),
+      format: new FunctionListToolCallPromptFormat(),
     }),
     calculator,
     "What's fourteen times twelve?"

--- a/examples/basic/src/model-provider/ollama/ollama-use-tool-mistral-example.ts
+++ b/examples/basic/src/model-provider/ollama/ollama-use-tool-mistral-example.ts
@@ -1,8 +1,7 @@
 import dotenv from "dotenv";
 import {
-  OllamaTextGenerationModel,
-  TextGenerationToolCallModel,
   FunctionListToolCallPromptFormat,
+  OllamaTextGenerationModel,
   useTool,
 } from "modelfusion";
 import { calculator } from "../../tool/calculator-tool";
@@ -11,14 +10,10 @@ dotenv.config();
 
 async function main() {
   const { tool, args, toolCall, result } = await useTool(
-    new TextGenerationToolCallModel({
-      model: new OllamaTextGenerationModel({
-        model: "mistral",
-        format: "json",
-        temperature: 0,
-      }),
-      format: new FunctionListToolCallPromptFormat(),
-    }),
+    new OllamaTextGenerationModel({
+      model: "mistral",
+      temperature: 0,
+    }).asToolCallGenerationModel(new FunctionListToolCallPromptFormat()),
     calculator,
     "What's fourteen times twelve?"
   );

--- a/examples/basic/src/model-provider/ollama/ollama-use-tool-openhermes-example.ts
+++ b/examples/basic/src/model-provider/ollama/ollama-use-tool-openhermes-example.ts
@@ -1,21 +1,32 @@
 import dotenv from "dotenv";
 import {
+  ChatMLPromptFormat,
   FunctionListToolCallPromptFormat,
+  OllamaApiConfiguration,
   OllamaTextGenerationModel,
+  retryNever,
+  setGlobalFunctionLogging,
   useTool,
 } from "modelfusion";
 import { calculator } from "../../tool/calculator-tool";
 
 dotenv.config();
 
+setGlobalFunctionLogging("detailed-object");
+
 async function main() {
   const { tool, args, toolCall, result } = await useTool(
     new OllamaTextGenerationModel({
-      model: "mistral",
+      model: "openhermes2.5-mistral",
       temperature: 0,
-    }).asToolCallGenerationModel(FunctionListToolCallPromptFormat.text()),
+      api: new OllamaApiConfiguration({ retry: retryNever() }),
+    }).asToolCallGenerationModel(
+      FunctionListToolCallPromptFormat.instruction({
+        baseFormat: ChatMLPromptFormat.instruction(),
+      })
+    ),
     calculator,
-    "What's fourteen times twelve?"
+    { instruction: "What's fourteen times twelve?" }
   );
 
   console.log(`Tool call`, toolCall);

--- a/examples/basic/src/model-provider/openai/openai-chat-stream-text-text-prompt-example.ts
+++ b/examples/basic/src/model-provider/openai/openai-chat-stream-text-text-prompt-example.ts
@@ -1,0 +1,19 @@
+import dotenv from "dotenv";
+import { OpenAIChatModel, streamText } from "modelfusion";
+
+dotenv.config();
+
+async function main() {
+  const textStream = await streamText(
+    new OpenAIChatModel({
+      model: "gpt-3.5-turbo",
+    }).withTextPrompt(),
+    "Write a short story about a robot learning to love."
+  );
+
+  for await (const textPart of textStream) {
+    process.stdout.write(textPart);
+  }
+}
+
+main().catch(console.error);

--- a/examples/basic/src/model-provider/openai/openai-generate-text-instruct-prompt-example.ts
+++ b/examples/basic/src/model-provider/openai/openai-generate-text-instruct-prompt-example.ts
@@ -10,10 +10,7 @@ async function main() {
       temperature: 0.7,
       maxCompletionTokens: 500,
     }).withInstructionPrompt(),
-    {
-      instruction: "Write a short story about:",
-      input: "a robot learning to love",
-    }
+    { instruction: "Write a story about a robot learning to love" }
   );
 
   console.log(text);

--- a/examples/basic/src/util/observer/execute-function-example.ts
+++ b/examples/basic/src/util/observer/execute-function-example.ts
@@ -39,8 +39,8 @@ async function main() {
         {
           instruction:
             "You generate Stable Diffusion prompts for images." +
-            "Generate a prompt for a high resolution, cyberpunk version of the following image description:",
-          input: imageDescription,
+            "Generate a prompt for a high resolution, cyberpunk version of the following image description:\n" +
+            imageDescription,
         },
         { functionId: "generate-image-prompt", ...options }
       );

--- a/examples/chatbot-next-js/src/pages/api/send-message.ts
+++ b/examples/chatbot-next-js/src/pages/api/send-message.ts
@@ -34,9 +34,7 @@ const gpt35turboModel = new OpenAIChatModel({
 const llama2Model = new LlamaCppTextGenerationModel({
   contextWindowSize: 4096, // Llama 2 context window size
   maxCompletionTokens: 512,
-})
-  .withTextPrompt()
-  .withPromptFormat(Llama2PromptFormat.chat());
+}).withTextPromptFormat(Llama2PromptFormat.chat());
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const cohereModel = new CohereTextGenerationModel({

--- a/examples/chatbot-terminal/src/default-prompt.ts
+++ b/examples/chatbot-terminal/src/default-prompt.ts
@@ -25,9 +25,7 @@ async function main() {
     const model = new LlamaCppTextGenerationModel({
       contextWindowSize: 4096,
       maxCompletionTokens: 512,
-    })
-      .withTextPrompt()
-      .withPromptFormat(TextPromptFormat.chat());
+    }).withTextPromptFormat(TextPromptFormat.chat());
 
     const textStream = await streamText(
       model,

--- a/examples/chatbot-terminal/src/llama2-prompt.ts
+++ b/examples/chatbot-terminal/src/llama2-prompt.ts
@@ -25,9 +25,7 @@ async function main() {
     const model = new LlamaCppTextGenerationModel({
       contextWindowSize: 4096, // Llama 2 context window size
       maxCompletionTokens: 512,
-    })
-      .withTextPrompt()
-      .withPromptFormat(Llama2PromptFormat.chat());
+    }).withTextPromptFormat(Llama2PromptFormat.chat());
 
     const textStream = await streamText(
       model,

--- a/src/core/api/retryWithExponentialBackoff.ts
+++ b/src/core/api/retryWithExponentialBackoff.ts
@@ -1,4 +1,5 @@
 import { delay } from "../../util/delay.js";
+import { getErrorMessage } from "../../util/getErrorMessage.js";
 import { ApiCallError } from "./ApiCallError.js";
 import { RetryError } from "./RetryError.js";
 import { RetryFunction } from "./RetryFunction.js";
@@ -32,12 +33,13 @@ async function _retryWithExponentialBackoff<OUTPUT>(
   try {
     return await f();
   } catch (error) {
+    const errorMessage = getErrorMessage(error);
     const newErrors = [...errors, error];
     const tryNumber = newErrors.length;
 
     if (tryNumber >= maxTries) {
       throw new RetryError({
-        message: `Failed after ${tryNumber} tries.`,
+        message: `Failed after ${tryNumber} tries. Last error: ${errorMessage}`,
         reason: "maxTriesExceeded",
         errors: newErrors,
       });
@@ -61,8 +63,6 @@ async function _retryWithExponentialBackoff<OUTPUT>(
         );
       }
     }
-
-    const errorMessage = error instanceof Error ? error.message : String(error);
 
     throw new RetryError({
       message: `Failed after ${tryNumber} attempt(s) with non-retryable error: '${errorMessage}'`,

--- a/src/model-function/generate-text/prompt-format/AlpacaPromptFormat.ts
+++ b/src/model-function/generate-text/prompt-format/AlpacaPromptFormat.ts
@@ -7,6 +7,23 @@ const DEFAULT_SYSTEM_PROMPT_NO_INPUT =
   "Below is an instruction that describes a task. Write a response that appropriately completes the request.";
 
 /**
+ * Formats a text prompt as an Alpaca prompt.
+ */
+export function text(): TextGenerationPromptFormat<string, string> {
+  return {
+    stopSequences: [],
+    format: (instruction) => {
+      let text = DEFAULT_SYSTEM_PROMPT_NO_INPUT;
+      text += "\n\n### Instruction:\n";
+      text += instruction;
+      text += "\n\n### Response:\n";
+
+      return text;
+    },
+  };
+}
+
+/**
  * Formats an instruction prompt as an Alpaca prompt.
  *
  * If the instruction has a system prompt, it overrides the default system prompt

--- a/src/model-function/generate-text/prompt-format/AlpacaPromptFormat.ts
+++ b/src/model-function/generate-text/prompt-format/AlpacaPromptFormat.ts
@@ -43,7 +43,7 @@ const DEFAULT_SYSTEM_PROMPT_NO_INPUT =
  * @see https://github.com/tatsu-lab/stanford_alpaca#data-release
  */
 export function instruction(): TextGenerationPromptFormat<
-  InstructionPrompt,
+  InstructionPrompt & { input?: string }, // optional input supported by Alpaca
   string
 > {
   return {

--- a/src/model-function/generate-text/prompt-format/ChatMLPromptFormat.ts
+++ b/src/model-function/generate-text/prompt-format/ChatMLPromptFormat.ts
@@ -38,12 +38,7 @@ export function instruction(): TextGenerationPromptFormat<
     stopSequences: [END_SEGMENT],
     format: (instruction) =>
       chatMLSegment("system", instruction.system) +
-      chatMLSegment(
-        "user",
-        instruction.instruction + instruction.input != null
-          ? `\n\n${instruction.input}`
-          : ""
-      ),
+      chatMLSegment("user", instruction.instruction),
   };
 }
 

--- a/src/model-function/generate-text/prompt-format/ChatMLPromptFormat.ts
+++ b/src/model-function/generate-text/prompt-format/ChatMLPromptFormat.ts
@@ -18,6 +18,16 @@ function chatMLSegment(
 }
 
 /**
+ * Formats a text prompt using the ChatML format.
+ */
+export function text(): TextGenerationPromptFormat<string, string> {
+  return {
+    stopSequences: [END_SEGMENT],
+    format: (instruction) => chatMLSegment("user", instruction),
+  };
+}
+
+/**
  * Formats an instruction prompt using the ChatML format.
  *
  * ChatML prompt template:

--- a/src/model-function/generate-text/prompt-format/InstructionPrompt.ts
+++ b/src/model-function/generate-text/prompt-format/InstructionPrompt.ts
@@ -1,13 +1,11 @@
 /**
- * A single instruction prompt. It can contain an optional system message to define the role and behavior of the language model
- * and an optiona input to provide context for the language model.
+ * A single instruction prompt. It can contain an optional system message to define the role and behavior of the language model.
  *
  * @example
  * ```ts
  * {
  *   system: "You are a celebrated poet.", // optional
- *   instruction: "Write a short story about:",
- *   input: "a robot learning to love.", // optional
+ *   instruction: "Write a story about a robot learning to love",
  * }
  * ```
  */
@@ -22,11 +20,6 @@ export type InstructionPrompt = {
    * The instruction for the model.
    */
   instruction: string;
-
-  /**
-   * Optional additional input or context, e.g. a the content from which information should be extracted.
-   */
-  input?: string;
 
   /**
    * Optional image to provide context for the language model. Only supported by some models.

--- a/src/model-function/generate-text/prompt-format/Llama2PromptFormat.ts
+++ b/src/model-function/generate-text/prompt-format/Llama2PromptFormat.ts
@@ -36,9 +36,7 @@ export function instruction(): TextGenerationPromptFormat<
         instruction.system != null
           ? ` ${BEGIN_SYSTEM}${instruction.system}${END_SYSTEM}`
           : ""
-      } ${instruction.instruction}${
-        instruction.input != null ? `\n\n${instruction.input}` : ""
-      } ${END_INSTRUCTION}\n`,
+      }${instruction.instruction}${END_INSTRUCTION}\n`,
   };
 }
 

--- a/src/model-function/generate-text/prompt-format/Llama2PromptFormat.ts
+++ b/src/model-function/generate-text/prompt-format/Llama2PromptFormat.ts
@@ -12,6 +12,24 @@ const BEGIN_SYSTEM = "<<SYS>>\n";
 const END_SYSTEM = "\n<</SYS>>\n\n";
 
 /**
+ * Formats a text prompt as a Llama 2 prompt.
+ *
+ * Llama 2 prompt template:
+ * ```
+ * <s>[INST]{ instruction } [/INST]
+ * ```
+ *
+ * @see https://www.philschmid.de/llama-2#how-to-prompt-llama-2-chat
+ */
+export function text(): TextGenerationPromptFormat<string, string> {
+  return {
+    stopSequences: [END_SEGMENT],
+    format: (instruction) =>
+      `${BEGIN_SEGMENT}${BEGIN_INSTRUCTION}${instruction}${END_INSTRUCTION}\n`,
+  };
+}
+
+/**
  * Formats an instruction prompt as a Llama 2 prompt.
  *
  * Llama 2 prompt template:

--- a/src/model-function/generate-text/prompt-format/TextPromptFormat.ts
+++ b/src/model-function/generate-text/prompt-format/TextPromptFormat.ts
@@ -4,6 +4,14 @@ import { TextGenerationPromptFormat } from "../TextGenerationPromptFormat.js";
 import { validateChatPrompt } from "./validateChatPrompt.js";
 
 /**
+ * Formats a text prompt as a basic text prompt. Does not change the text prompt in any way.
+ */
+export const text: () => TextGenerationPromptFormat<string, string> = () => ({
+  stopSequences: [],
+  format: (instruction) => instruction,
+});
+
+/**
  * Formats an instruction prompt as a basic text prompt.
  */
 export const instruction: () => TextGenerationPromptFormat<

--- a/src/model-function/generate-text/prompt-format/TextPromptFormat.ts
+++ b/src/model-function/generate-text/prompt-format/TextPromptFormat.ts
@@ -20,10 +20,6 @@ export const instruction: () => TextGenerationPromptFormat<
 
     text += instruction.instruction;
 
-    if (instruction.input != null) {
-      text += `\n\n${instruction.input}`;
-    }
-
     return text;
   },
 });

--- a/src/model-provider/anthropic/AnthropicPromptFormat.ts
+++ b/src/model-provider/anthropic/AnthropicPromptFormat.ts
@@ -22,12 +22,6 @@ export function instruction(): TextGenerationPromptFormat<
 
       text += instruction.instruction;
 
-      if (instruction.input != null) {
-        // use tags per Anthropic instruction:
-        // https://docs.anthropic.com/claude/docs/constructing-a-prompt
-        text += `\n\n<data>${instruction.input}</data>`;
-      }
-
       text += "\n\nAssistant:";
 
       return text;

--- a/src/model-provider/anthropic/AnthropicPromptFormat.ts
+++ b/src/model-provider/anthropic/AnthropicPromptFormat.ts
@@ -4,6 +4,23 @@ import { TextGenerationPromptFormat } from "../../model-function/generate-text/T
 import { validateChatPrompt } from "../../model-function/generate-text/prompt-format/validateChatPrompt.js";
 
 /**
+ * Formats a text prompt as an Anthropic prompt.
+ */
+export function text(): TextGenerationPromptFormat<string, string> {
+  return {
+    format: (instruction) => {
+      let text = "";
+      text += "\n\nHuman:";
+      text += instruction;
+      text += "\n\nAssistant:";
+
+      return text;
+    },
+    stopSequences: [],
+  };
+}
+
+/**
  * Formats an instruction prompt as an Anthropic prompt.
  */
 export function instruction(): TextGenerationPromptFormat<
@@ -19,9 +36,7 @@ export function instruction(): TextGenerationPromptFormat<
       }
 
       text += "\n\nHuman:";
-
       text += instruction.instruction;
-
       text += "\n\nAssistant:";
 
       return text;

--- a/src/model-provider/anthropic/AnthropicTextGenerationModel.ts
+++ b/src/model-provider/anthropic/AnthropicTextGenerationModel.ts
@@ -21,7 +21,7 @@ import { ZodSchema } from "../../core/schema/ZodSchema.js";
 import { parseJSON } from "../../core/schema/parseJSON.js";
 import { AnthropicApiConfiguration } from "./AnthropicApiConfiguration.js";
 import { failedAnthropicCallResponseHandler } from "./AnthropicError.js";
-import { instruction, chat } from "./AnthropicPromptFormat.js";
+import { instruction, chat, text } from "./AnthropicPromptFormat.js";
 
 export const ANTHROPIC_TEXT_GENERATION_MODELS = {
   "claude-instant-1": {
@@ -136,6 +136,13 @@ export class AnthropicTextGenerationModel
       ...options,
       responseFormat: AnthropicTextGenerationResponseFormat.deltaIterable,
     });
+  }
+
+  /**
+   * Returns this model with a text prompt format.
+   */
+  withTextPrompt() {
+    return this.withPromptFormat(text());
   }
 
   /**

--- a/src/model-provider/llamacpp/LlamaCppBakLLaVA1Format.ts
+++ b/src/model-provider/llamacpp/LlamaCppBakLLaVA1Format.ts
@@ -30,10 +30,6 @@ export function instruction(): TextGenerationPromptFormat<
 
       text += `${instruction.instruction}\n`;
 
-      if (instruction.input != null) {
-        text += `${instruction.input}\n`;
-      }
-
       text += `ASSISTANT: `;
 
       return {

--- a/src/model-provider/llamacpp/LlamaCppTextGenerationModel.ts
+++ b/src/model-provider/llamacpp/LlamaCppTextGenerationModel.ts
@@ -187,7 +187,12 @@ export class LlamaCppTextGenerationModel<
     });
   }
 
-  withTextPrompt() {
+  withTextPrompt(): PromptFormatTextStreamingModel<
+    string,
+    LlamaCppTextGenerationPrompt,
+    LlamaCppTextGenerationModelSettings<CONTEXT_WINDOW_SIZE>,
+    this
+  > {
     return this.withPromptFormat({
       format(prompt: string) {
         return { text: prompt };
@@ -196,6 +201,36 @@ export class LlamaCppTextGenerationModel<
     });
   }
 
+  /**
+   * Maps the prompt for a text version of the Llama.cpp prompt format (without image support).
+   */
+  withTextPromptFormat<INPUT_PROMPT>(
+    promptFormat: TextGenerationPromptFormat<INPUT_PROMPT, string>
+  ): PromptFormatTextStreamingModel<
+    INPUT_PROMPT,
+    string,
+    LlamaCppTextGenerationModelSettings<CONTEXT_WINDOW_SIZE>,
+    PromptFormatTextStreamingModel<
+      string,
+      LlamaCppTextGenerationPrompt,
+      LlamaCppTextGenerationModelSettings<CONTEXT_WINDOW_SIZE>,
+      this
+    >
+  > {
+    return new PromptFormatTextStreamingModel({
+      model: this.withTextPrompt().withSettings({
+        stopSequences: [
+          ...(this.settings.stopSequences ?? []),
+          ...promptFormat.stopSequences,
+        ],
+      }),
+      promptFormat,
+    });
+  }
+
+  /**
+   * Maps the prompt for the full Llama.cpp prompt format (incl. image support).
+   */
   withPromptFormat<INPUT_PROMPT>(
     promptFormat: TextGenerationPromptFormat<
       INPUT_PROMPT,

--- a/src/model-provider/ollama/OllamaTextGenerationModel.ts
+++ b/src/model-provider/ollama/OllamaTextGenerationModel.ts
@@ -250,7 +250,9 @@ export class OllamaTextGenerationModel<
     });
   }
 
-  asToolCallGenerationModel(promptFormat: ToolCallPromptFormat<string>) {
+  asToolCallGenerationModel<INPUT_PROMPT>(
+    promptFormat: ToolCallPromptFormat<INPUT_PROMPT, string>
+  ) {
     return new TextGenerationToolCallModel({
       model: this.withSettings({ format: "json" }),
       format: promptFormat,

--- a/src/model-provider/ollama/OllamaTextGenerationModel.ts
+++ b/src/model-provider/ollama/OllamaTextGenerationModel.ts
@@ -16,6 +16,10 @@ import {
   TextStreamingModel,
 } from "../../model-function/generate-text/TextGenerationModel.js";
 import { TextGenerationPromptFormat } from "../../model-function/generate-text/TextGenerationPromptFormat.js";
+import {
+  TextGenerationToolCallModel,
+  ToolCallPromptFormat,
+} from "../../tool/generate-tool-call/TextGenerationToolCallModel.js";
 import { AsyncQueue } from "../../util/AsyncQueue.js";
 import { parseJsonStream } from "../../util/streaming/parseJsonStream.js";
 import { OllamaApiConfiguration } from "./OllamaApiConfiguration.js";
@@ -243,6 +247,13 @@ export class OllamaTextGenerationModel<
     return this.callAPI(prompt, {
       ...options,
       responseFormat: OllamaTextGenerationResponseFormat.deltaIterable,
+    });
+  }
+
+  asToolCallGenerationModel(promptFormat: ToolCallPromptFormat<string>) {
+    return new TextGenerationToolCallModel({
+      model: this.withSettings({ format: "json" }),
+      format: promptFormat,
     });
   }
 

--- a/src/model-provider/openai/chat/OpenAIChatModel.ts
+++ b/src/model-provider/openai/chat/OpenAIChatModel.ts
@@ -28,7 +28,7 @@ import { OpenAIApiConfiguration } from "../OpenAIApiConfiguration.js";
 import { failedOpenAICallResponseHandler } from "../OpenAIError.js";
 import { TikTokenTokenizer } from "../TikTokenTokenizer.js";
 import { OpenAIChatMessage } from "./OpenAIChatMessage.js";
-import { chat, instruction } from "./OpenAIChatPromptFormat.js";
+import { chat, instruction, text } from "./OpenAIChatPromptFormat.js";
 import { createOpenAIChatDeltaIterableQueue } from "./OpenAIChatStreamIterable.js";
 import { countOpenAIChatPromptTokens } from "./countOpenAIChatMessageTokens.js";
 
@@ -541,6 +541,12 @@ export class OpenAIChatModel
       completionTokens: response.usage.completion_tokens,
       totalTokens: response.usage.total_tokens,
     };
+  }
+  /**
+   * Returns this model with a text prompt format.
+   */
+  withTextPrompt() {
+    return this.withPromptFormat(text());
   }
 
   /**

--- a/src/model-provider/openai/chat/OpenAIChatPromptFormat.ts
+++ b/src/model-provider/openai/chat/OpenAIChatPromptFormat.ts
@@ -5,6 +5,19 @@ import { validateChatPrompt } from "../../../model-function/generate-text/prompt
 import { OpenAIChatMessage } from "./OpenAIChatMessage.js";
 
 /**
+ * Formats a text prompt as an OpenAI chat prompt.
+ */
+export function text(): TextGenerationPromptFormat<
+  string,
+  Array<OpenAIChatMessage>
+> {
+  return {
+    format: (instruction) => [OpenAIChatMessage.user(instruction)],
+    stopSequences: [],
+  };
+}
+
+/**
  * Formats an instruction prompt as an OpenAI chat prompt.
  */
 export function instruction(): TextGenerationPromptFormat<

--- a/src/model-provider/openai/chat/OpenAIChatPromptFormat.ts
+++ b/src/model-provider/openai/chat/OpenAIChatPromptFormat.ts
@@ -25,10 +25,6 @@ export function instruction(): TextGenerationPromptFormat<
         })
       );
 
-      if (instruction.input != null) {
-        messages.push(OpenAIChatMessage.user(instruction.input));
-      }
-
       return messages;
     },
     stopSequences: [],

--- a/src/tool/generate-tool-call/FunctionListToolCallPromptFormat.ts
+++ b/src/tool/generate-tool-call/FunctionListToolCallPromptFormat.ts
@@ -2,6 +2,8 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 import { ZodSchema } from "../../core/schema/ZodSchema.js";
 import { parseJSON } from "../../core/schema/parseJSON.js";
+import { PromptFormat } from "../../model-function/PromptFormat.js";
+import { InstructionPrompt } from "../../model-function/generate-text/prompt-format/InstructionPrompt.js";
 import { ToolDefinition } from "../ToolDefinition.js";
 import { ToolCallPromptFormat } from "./TextGenerationToolCallModel.js";
 
@@ -21,36 +23,89 @@ const DEFAULT_FUNCTION_CALL_PROMPT = [
   `Available functions:`,
 ].join("\n");
 
-export class FunctionListToolCallPromptFormat
-  implements ToolCallPromptFormat<string>
-{
-  readonly functionCallPrompt: string;
+export function text(options?: {
+  functionCallPrompt?: string;
+}): ToolCallPromptFormat<string, string>;
+export function text<TARGET_PROMPT>({
+  functionCallPrompt,
+  baseFormat,
+}: {
+  functionCallPrompt?: string;
+  baseFormat: PromptFormat<string, TARGET_PROMPT>;
+}): ToolCallPromptFormat<string, TARGET_PROMPT>;
+export function text<TARGET_PROMPT>({
+  functionCallPrompt = DEFAULT_FUNCTION_CALL_PROMPT,
+  baseFormat,
+}: {
+  functionCallPrompt?: string;
+  baseFormat?: PromptFormat<string, TARGET_PROMPT>;
+} = {}):
+  | ToolCallPromptFormat<string, TARGET_PROMPT>
+  | ToolCallPromptFormat<string, string> {
+  return {
+    createPrompt(
+      instruction: string,
+      tool: ToolDefinition<string, unknown>
+    ): string {
+      const instructionWithFunctionCall = [
+        instruction,
+        functionCallPrompt,
+        `${tool.name}:`,
+        `  description: ${tool.description ?? ""}`,
+        `  parameters: ${JSON.stringify(tool.parameters.getJsonSchema())}`,
+        ``,
+      ].join("\n");
 
-  constructor({
-    functionCallPrompt = DEFAULT_FUNCTION_CALL_PROMPT,
-  }: { functionCallPrompt?: string } = {}) {
-    this.functionCallPrompt = functionCallPrompt;
-  }
+      return (baseFormat?.format(instructionWithFunctionCall) ??
+        // handled by signature overloading:
+        instructionWithFunctionCall) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    },
 
-  createPrompt(
-    instruction: string,
-    tool: ToolDefinition<string, unknown>
-  ): string {
-    return [
-      instruction,
-      this.functionCallPrompt,
-      `${tool.name}:`,
-      `  description: ${tool.description ?? ""}`,
-      `  parameters: ${JSON.stringify(tool.parameters.getJsonSchema())}`,
-      ``,
-    ].join("\n");
-  }
+    extractToolCall(response: string) {
+      const json = parseJSON({ text: response, schema: functionSchema });
+      return {
+        id: nanoid(),
+        args: json.parameters,
+      };
+    },
+  } satisfies
+    | ToolCallPromptFormat<string, TARGET_PROMPT>
+    | ToolCallPromptFormat<string, string>;
+}
 
-  extractToolCall(response: string) {
-    const json = parseJSON({ text: response, schema: functionSchema });
-    return {
-      id: nanoid(),
-      args: json.parameters,
-    };
-  }
+export function instruction<TARGET_PROMPT>({
+  functionCallPrompt = DEFAULT_FUNCTION_CALL_PROMPT,
+  baseFormat,
+}: {
+  functionCallPrompt?: string;
+  baseFormat: PromptFormat<InstructionPrompt, TARGET_PROMPT>;
+}): ToolCallPromptFormat<InstructionPrompt, TARGET_PROMPT> {
+  return {
+    createPrompt(
+      instruction: InstructionPrompt,
+      tool: ToolDefinition<string, unknown>
+    ): TARGET_PROMPT {
+      const instructionWithFunctionCall = [
+        instruction.instruction,
+        functionCallPrompt,
+        `${tool.name}:`,
+        `  description: ${tool.description ?? ""}`,
+        `  parameters: ${JSON.stringify(tool.parameters.getJsonSchema())}`,
+        ``,
+      ].join("\n");
+
+      return baseFormat.format({
+        ...instruction,
+        instruction: instructionWithFunctionCall,
+      });
+    },
+
+    extractToolCall(response: string) {
+      const json = parseJSON({ text: response, schema: functionSchema });
+      return {
+        id: nanoid(),
+        args: json.parameters,
+      };
+    },
+  };
 }

--- a/src/tool/generate-tool-call/FunctionListToolCallPromptFormat.ts
+++ b/src/tool/generate-tool-call/FunctionListToolCallPromptFormat.ts
@@ -1,0 +1,56 @@
+import { nanoid } from "nanoid";
+import { z } from "zod";
+import { ZodSchema } from "../../core/schema/ZodSchema.js";
+import { parseJSON } from "../../core/schema/parseJSON.js";
+import { ToolDefinition } from "../ToolDefinition.js";
+import { ToolCallPromptFormat } from "./TextGenerationToolCallModel.js";
+
+const functionSchema = new ZodSchema(
+  z.object({
+    function: z.string(),
+    parameters: z.any(),
+  })
+);
+
+const DEFAULT_FUNCTION_CALL_PROMPT = [
+  ``,
+  `Select the most suitable function and parameters ` +
+    `from the list of available functions below, based on the user's input. ` +
+    `Provide your response in JSON format.`,
+  ``,
+  `Available functions:`,
+].join("\n");
+
+export class FunctionListToolCallPromptFormat
+  implements ToolCallPromptFormat<string>
+{
+  readonly functionCallPrompt: string;
+
+  constructor({
+    functionCallPrompt = DEFAULT_FUNCTION_CALL_PROMPT,
+  }: { functionCallPrompt?: string } = {}) {
+    this.functionCallPrompt = functionCallPrompt;
+  }
+
+  createPrompt(
+    instruction: string,
+    tool: ToolDefinition<string, unknown>
+  ): string {
+    return [
+      instruction,
+      this.functionCallPrompt,
+      `${tool.name}:`,
+      `  description: ${tool.description ?? ""}`,
+      `  parameters: ${JSON.stringify(tool.parameters.getJsonSchema())}`,
+      ``,
+    ].join("\n");
+  }
+
+  extractToolCall(response: string) {
+    const json = parseJSON({ text: response, schema: functionSchema });
+    return {
+      id: nanoid(),
+      args: json.parameters,
+    };
+  }
+}

--- a/src/tool/generate-tool-call/TextGenerationToolCallModel.ts
+++ b/src/tool/generate-tool-call/TextGenerationToolCallModel.ts
@@ -8,7 +8,7 @@ import { ToolCallParseError } from "../ToolCallParseError.js";
 import { ToolDefinition } from "../ToolDefinition.js";
 import { ToolCallGenerationModel } from "./ToolCallGenerationModel.js";
 
-export interface ToolCallTextPromptFormat<PROMPT> {
+export interface ToolCallPromptFormat<PROMPT> {
   createPrompt: (
     prompt: PROMPT,
     tool: ToolDefinition<string, unknown>
@@ -22,14 +22,14 @@ export class TextGenerationToolCallModel<
 > implements ToolCallGenerationModel<PROMPT, MODEL["settings"]>
 {
   private readonly model: MODEL;
-  private readonly format: ToolCallTextPromptFormat<PROMPT>;
+  private readonly format: ToolCallPromptFormat<PROMPT>;
 
   constructor({
     model,
     format,
   }: {
     model: MODEL;
-    format: ToolCallTextPromptFormat<PROMPT>;
+    format: ToolCallPromptFormat<PROMPT>;
   }) {
     this.model = model;
     this.format = format;

--- a/src/tool/generate-tool-call/TextGenerationToolCallModel.ts
+++ b/src/tool/generate-tool-call/TextGenerationToolCallModel.ts
@@ -8,28 +8,29 @@ import { ToolCallParseError } from "../ToolCallParseError.js";
 import { ToolDefinition } from "../ToolDefinition.js";
 import { ToolCallGenerationModel } from "./ToolCallGenerationModel.js";
 
-export interface ToolCallPromptFormat<PROMPT> {
+export interface ToolCallPromptFormat<SOURCE_PROMPT, TARGET_PROMPT> {
   createPrompt: (
-    prompt: PROMPT,
+    prompt: SOURCE_PROMPT,
     tool: ToolDefinition<string, unknown>
-  ) => string;
+  ) => TARGET_PROMPT;
   extractToolCall: (response: string) => { id: string; args: unknown } | null;
 }
 
 export class TextGenerationToolCallModel<
-  PROMPT,
-  MODEL extends TextGenerationModel<string, TextGenerationModelSettings>,
-> implements ToolCallGenerationModel<PROMPT, MODEL["settings"]>
+  SOURCE_PROMPT,
+  TARGET_PROMPT,
+  MODEL extends TextGenerationModel<TARGET_PROMPT, TextGenerationModelSettings>,
+> implements ToolCallGenerationModel<SOURCE_PROMPT, MODEL["settings"]>
 {
   private readonly model: MODEL;
-  private readonly format: ToolCallPromptFormat<PROMPT>;
+  private readonly format: ToolCallPromptFormat<SOURCE_PROMPT, TARGET_PROMPT>;
 
   constructor({
     model,
     format,
   }: {
     model: MODEL;
-    format: ToolCallPromptFormat<PROMPT>;
+    format: ToolCallPromptFormat<SOURCE_PROMPT, TARGET_PROMPT>;
   }) {
     this.model = model;
     this.format = format;
@@ -49,7 +50,7 @@ export class TextGenerationToolCallModel<
 
   async doGenerateToolCall(
     tool: ToolDefinition<string, unknown>,
-    prompt: PROMPT,
+    prompt: SOURCE_PROMPT,
     options?: FunctionOptions
   ) {
     const { response, value, metadata } = await generateText(

--- a/src/tool/generate-tool-call/index.ts
+++ b/src/tool/generate-tool-call/index.ts
@@ -1,5 +1,5 @@
+export * as FunctionListToolCallPromptFormat from "./FunctionListToolCallPromptFormat.js";
 export * from "./TextGenerationToolCallModel.js";
 export * from "./ToolCallGenerationEvent.js";
 export * from "./ToolCallGenerationModel.js";
 export * from "./generateToolCall.js";
-export * from "./FunctionListToolCallPromptFormat.js";

--- a/src/tool/generate-tool-call/index.ts
+++ b/src/tool/generate-tool-call/index.ts
@@ -2,3 +2,4 @@ export * from "./TextGenerationToolCallModel.js";
 export * from "./ToolCallGenerationEvent.js";
 export * from "./ToolCallGenerationModel.js";
 export * from "./generateToolCall.js";
+export * from "./FunctionListToolCallPromptFormat.js";


### PR DESCRIPTION
* remove `input` from `InstructionPrompt` (was Alpaca-specific, `AlpacaPromptFormat` still supports it)
* improve error reporting when using exponent backoff retries
* add text prompt format. Use simple text prompts, e.g. with `OpenAIChatModel`:
   ```ts
  const textStream = await streamText(
    new OpenAIChatModel({
      model: "gpt-3.5-turbo",
    }).withTextPrompt(),
    "Write a short story about a robot learning to love."
  );
  ```
* add `.withTextPromptFormat` to `LlamaCppTextGenerationModel` for simplified prompt construction:
   ```ts
  const textStream = await streamText(
    new LlamaCppTextGenerationModel({
      // ...
    }).withTextPromptFormat(Llama2PromptFormat.text()),
    "Write a short story about a robot learning to love."
  );
  ```
* add `FunctionListToolCallPromptFormat` to simplify tool calls with text models
* add `.asToolCallGenerationModel()` to `OllamaTextGenerationModel` to simplify tool calls:
   ```ts
  const { tool, args, toolCall, result } = await useTool(
    new OllamaTextGenerationModel({
      model: "mistral",
      temperature: 0,
    }).asToolCallGenerationModel(FunctionListToolCallPromptFormat.text()),
    calculator,
    "What's fourteen times twelve?"
  );
  ```