### PR TITLE
Make maxValuesPerCall configurable for OpenAI text embedding models

### DIFF
--- a/src/model-provider/openai/OpenAITextEmbeddingModel.ts
+++ b/src/model-provider/openai/OpenAITextEmbeddingModel.ts
@@ -53,6 +53,7 @@ export const calculateOpenAIEmbeddingCostInMillicents = ({
 export interface OpenAITextEmbeddingModelSettings
   extends EmbeddingModelSettings {
   api?: ApiConfiguration;
+  maxValuesPerCall?: number | undefined;
   model: OpenAITextEmbeddingModelType;
   isUserIdForwardingEnabled?: boolean;
 }


### PR DESCRIPTION
I hope that's the right approach. 