### PR TITLE
Add support for llama.cpp cache_prompt parameter

### DIFF
--- a/src/model-provider/llamacpp/LlamaCppTextGenerationModel.ts
+++ b/src/model-provider/llamacpp/LlamaCppTextGenerationModel.ts
@@ -34,6 +34,7 @@ export interface LlamaCppTextGenerationModelSettings<
    */
   contextWindowSize?: CONTEXT_WINDOW_SIZE;
 
+  cachePrompt?: boolean;
   temperature?: number;
   topK?: number;
   topP?: number;
@@ -126,6 +127,7 @@ export class LlamaCppTextGenerationModel<
       "stopSequences",
 
       "contextWindowSize",
+      "cachePrompt",
       "temperature",
       "topK",
       "topP",
@@ -333,6 +335,7 @@ async function callLlamaCppTextGenerationAPI<RESPONSE>({
   abortSignal,
   responseFormat,
   prompt,
+  cachePrompt,
   temperature,
   topK,
   topP,
@@ -355,6 +358,7 @@ async function callLlamaCppTextGenerationAPI<RESPONSE>({
   abortSignal?: AbortSignal;
   responseFormat: LlamaCppTextGenerationResponseFormatType<RESPONSE>;
   prompt: LlamaCppTextGenerationPrompt;
+  cachePrompt?: boolean;
   temperature?: number;
   topK?: number;
   topP?: number;
@@ -379,6 +383,7 @@ async function callLlamaCppTextGenerationAPI<RESPONSE>({
     body: {
       stream: responseFormat.stream,
       prompt: prompt.text,
+      cache_prompt: cachePrompt,
       temperature,
       top_k: topK,
       top_p: topP,


### PR DESCRIPTION
llama.cpp recently added a cache_prompt parameter to its API:  https://github.com/ggerganov/llama.cpp/commit/05cd6e5036d72d0930de4d8f6be7bce09e8dda24

It does the following (described in the llama.cpp server [README](https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md#api-endpoints)):
> cache_prompt: Save the prompt and generation for avoid reprocess entire prompt if a part of this isn't change (default: false)

This PR adds support for it. The build runs and the functionality seems to work as intended in my project.