### PR TITLE
Update OllamaCompletionModel.ts

### DIFF
--- a/packages/modelfusion/src/model-provider/ollama/OllamaCompletionModel.ts
+++ b/packages/modelfusion/src/model-provider/ollama/OllamaCompletionModel.ts
@@ -352,7 +352,7 @@ const ollamaCompletionResponseSchema = z.object({
   response: z.string(),
   total_duration: z.number(),
   load_duration: z.number().optional(),
-  prompt_eval_count: z.number(),
+  prompt_eval_count: z.number().optional(),
   prompt_eval_duration: z.number().optional(),
   eval_count: z.number(),
   eval_duration: z.number(),


### PR DESCRIPTION
#251  fixes. 
example response which is valid but got throw error 

```
{
    "model": "phi:latest",
    "created_at": "2024-01-11T04:36:17.994917Z",
    "response": " AI Assistant: Why don't scientists trust atoms? Because they make up everything! 😜 (Puns are often based on wordplay with \"atoms\" as both a unit of measurement and the smallest unit of matter.)\n",
    "done": true,
    "context": [
        11964,
        25,
        317,
        8537,
        1022,
        257,
        11040,
        2836,
        290,
        281,
        11666,
        4430,
        8796,
        13,
        383,
        8796,
        3607,
        7613,
        7429,
        284,
        262,
        2836,
        338,
        2683,
        13,
        198,
        12982,
        25,
        220,
        198,
        198,
        15883,
        257,
        9707,
        628,
        198,
        48902,
        25,
        9552,
        15286,
        25,
        4162,
        836,
        470,
        5519,
        3774,
        23235,
        30,
        4362,
        484,
        787,
        510,
        2279,
        0,
        30325,
        250,
        357,
        47,
        13271,
        389,
        1690,
        1912,
        319,
        1573,
        1759,
        351,
        366,
        265,
        3150,
        1,
        355,
        1111,
        257,
        4326,
        286,
        15558,
        290,
        262,
        18197,
        4326,
        286,
        2300,
        2014,
        198
    ],
    "total_duration": 523187958,
    "load_duration": 626583,
    "prompt_eval_duration": 103354000,
    "eval_count": 46,
    "eval_duration": 416464000
}
```