### PR TITLE
fix-copy-files-path

### DIFF
--- a/packages/modelfusion/package.json
+++ b/packages/modelfusion/package.json
@@ -61,7 +61,7 @@
     "clean": "rimraf build dist .turbo node_modules",
     "clean:build": "rimraf build dist",
     "build": "tsup && pnpm build:copy-files",
-    "build:copy-files": "copyfiles --flat package.json ./README.md ../../LICENSE ./CHANGELOG.md dist",
+    "build:copy-files": "copyfiles --flat package.json ../../README.md ../../LICENSE ../../CHANGELOG.md dist",
     "test": "vitest --config vitest.config.js --run src",
     "test:watch": "vitest watch --config vitest.config.js",
     "test:coverage": "vitest run --config vitest.config.js --coverage",


### PR DESCRIPTION
The complied modelfusion workspace/package is no longer including a REAMDE, LICENSE, or CHANGELOG.  Just fixed the paths in the package.json.  Now the npm registry should show a README again when navigating to https://www.npmjs.com/package/modelfusion.